### PR TITLE
Enhance 30 jwt token

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -24,6 +24,6 @@ export class AuthController {
   @UseGuards(RefreshJwtAuthGuard)
   @Get('refresh')
   async refresh(@Req() req) {
-    return await this.authService.refresh(req.user.uuid, req.user.sub);
+    return await this.authService.refresh(req.user.uuid, req.user.userId);
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,9 +1,9 @@
+import { JwtTokenResponse } from './dto/jwt-token.dto';
 import { Controller, Get, Req, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { KakaoAuthGuard } from './guard/kakao-auth.guard';
-import { JwtToken } from './dto/jwt-token.dto';
 import { ApiTags } from '@nestjs/swagger';
-import { RefreshJwtStrategy } from './strategy/refresh-jwt.strategy';
+import { RefreshJwtAuthGuard } from './guard/refresh-jwt-auth.guard';
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
@@ -11,13 +11,19 @@ export class AuthController {
 
   @UseGuards(KakaoAuthGuard)
   @Get('login/kakao')
-  async loginWithKakao(@Req() req): Promise<JwtToken> {
+  async loginWithKakao(@Req() req): Promise<JwtTokenResponse> {
     return await this.authService.login(req.user);
   }
 
-  @UseGuards(RefreshJwtStrategy)
+  @UseGuards(RefreshJwtAuthGuard)
   @Get('logout')
   async logout(@Req() req) {
-    return await this.authService.logout(req.user);
+    return await this.authService.logout(req.user.uuid);
+  }
+
+  @UseGuards(RefreshJwtAuthGuard)
+  @Get('refresh')
+  async refresh(@Req() req) {
+    return await this.authService.refresh(req.user.uuid, req.user.sub);
   }
 }

--- a/src/auth/auth.repository.ts
+++ b/src/auth/auth.repository.ts
@@ -1,23 +1,31 @@
-import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common';
-import { Cache } from 'cache-manager';
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from 'src/database/database.service';
 
 @Injectable()
 export class AuthRepository {
-  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+  constructor(private databaseService: DatabaseService) {}
+  private readonly schema = process.env.DATABASE_APPLICATION_SCHEMA;
+  private readonly userTable = `${this.schema}.user`;
+  private readonly tokenTable = `${this.schema}.token`;
 
-  async save(uuid: string, token: string, ttl: number): Promise<void> {
-    await this.cacheManager.set(uuid, token, { ttl });
+  async saveToken(uuid: string) {
+    const result = await this.databaseService.query<{ id: string }>(`
+    INSERT INTO ${this.tokenTable} (id) VALUES ('${uuid}') RETURNING id;
+    `);
+    return result.length === 1 ? result[0].id : null;
   }
 
-  async find(uuid: string): Promise<string | null> {
-    return this.cacheManager.get(uuid);
+  async deleteToken(uuid: string) {
+    const result = await this.databaseService.query<{ id: string }>(`
+    DELETE FROM ${this.tokenTable} WHERE id='${uuid}';
+    `);
+    return result.length === 1 ? result[0].id : null;
   }
 
-  async delete(uuid: string): Promise<void> {
-    await this.cacheManager.del(uuid);
-  }
-
-  async reset(): Promise<void> {
-    await this.cacheManager.reset();
+  async findToken(uuid: string) {
+    const result = await this.databaseService.query<{ id: string }>(`
+    SELECT id FROM ${this.tokenTable} WHERE id='${uuid}';
+    `);
+    return result.length === 1 ? result[0].id : null;
   }
 }

--- a/src/auth/auth.repository.ts
+++ b/src/auth/auth.repository.ts
@@ -5,10 +5,9 @@ import { DatabaseService } from 'src/database/database.service';
 export class AuthRepository {
   constructor(private databaseService: DatabaseService) {}
   private readonly schema = process.env.DATABASE_APPLICATION_SCHEMA;
-  private readonly userTable = `${this.schema}.user`;
   private readonly tokenTable = `${this.schema}.token`;
 
-  async saveToken(uuid: string) {
+  async createToken(uuid: string) {
     const result = await this.databaseService.query<{ id: string }>(`
     INSERT INTO ${this.tokenTable} (id) VALUES ('${uuid}') RETURNING id;
     `);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,5 +1,3 @@
-import { UsersRepository } from './../users/users.repository';
-import { UsersService } from './../users/users.service';
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { AuthRepository } from './auth.repository';

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -11,8 +11,6 @@ export class AuthService {
   constructor(
     private jwtService: JwtService,
     private authRepository: AuthRepository,
-    private usersService: UsersService,
-    private usersRepository: UsersRepository,
   ) {}
 
   async login(userId: number): Promise<JwtTokenResponse> {
@@ -21,7 +19,7 @@ export class AuthService {
     const accessToken = this.jwtService.sign(payload);
     const expiresIn = parseInt(process.env.JWT_REFRESH_EXPIRES_IN);
     const refreshToken = this.jwtService.sign(payload, { expiresIn });
-    await this.authRepository.saveToken(uuid);
+    await this.authRepository.createToken(uuid);
     return {
       accessToken,
       refreshToken,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,11 +1,10 @@
 import { UsersRepository } from './../users/users.repository';
-import { JwtPayload } from './dto/jwt-payload.dto';
 import { UsersService } from './../users/users.service';
 import { Injectable } from '@nestjs/common';
-import { v4 as uuid4 } from 'uuid';
 import { JwtService } from '@nestjs/jwt';
 import { AuthRepository } from './auth.repository';
-import { JwtToken } from './dto/jwt-token.dto';
+import { JwtPayload, JwtTokenResponse } from './dto/jwt-token.dto';
+import { v4 as uuid4 } from 'uuid';
 
 @Injectable()
 export class AuthService {
@@ -16,20 +15,25 @@ export class AuthService {
     private usersRepository: UsersRepository,
   ) {}
 
-  async login(userId: number): Promise<JwtToken> {
+  async login(userId: number): Promise<JwtTokenResponse> {
     const uuid = uuid4();
     const payload: JwtPayload = { uuid, sub: userId };
     const accessToken = this.jwtService.sign(payload);
     const expiresIn = parseInt(process.env.JWT_REFRESH_EXPIRES_IN);
     const refreshToken = this.jwtService.sign(payload, { expiresIn });
-    this.authRepository.save(uuid, refreshToken, expiresIn);
+    await this.authRepository.saveToken(uuid);
     return {
       accessToken,
       refreshToken,
     };
   }
 
-  async logout(user: any): Promise<void> {
-    await this.authRepository.delete(user.uuid);
+  async logout(uuid: string): Promise<void> {
+    await this.authRepository.deleteToken(uuid);
+  }
+
+  async refresh(uuid: string, userId: number): Promise<JwtTokenResponse> {
+    await this.authRepository.deleteToken(uuid);
+    return await this.login(userId);
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -13,7 +13,7 @@ export class AuthService {
 
   async login(userId: number): Promise<JwtTokenResponse> {
     const uuid = uuid4();
-    const payload: JwtPayload = { uuid, sub: userId };
+    const payload: JwtPayload = { uuid, userId: userId };
     const accessToken = this.jwtService.sign(payload);
     const expiresIn = parseInt(process.env.JWT_REFRESH_EXPIRES_IN);
     const refreshToken = this.jwtService.sign(payload, { expiresIn });

--- a/src/auth/dto/jwt-payload.dto.ts
+++ b/src/auth/dto/jwt-payload.dto.ts
@@ -1,4 +1,0 @@
-export class JwtPayload {
-  uuid: string;
-  sub: number;
-}

--- a/src/auth/dto/jwt-token.dto.ts
+++ b/src/auth/dto/jwt-token.dto.ts
@@ -1,4 +1,9 @@
-export class JwtToken {
+export type JwtTokenResponse = {
   accessToken: string;
   refreshToken: string;
-}
+};
+
+export type JwtPayload = {
+  uuid: string;
+  sub: number;
+};

--- a/src/auth/dto/jwt-token.dto.ts
+++ b/src/auth/dto/jwt-token.dto.ts
@@ -5,5 +5,5 @@ export type JwtTokenResponse = {
 
 export type JwtPayload = {
   uuid: string;
-  sub: number;
+  userId: number;
 };

--- a/src/auth/guard/refresh-jwt-auth.guard.ts
+++ b/src/auth/guard/refresh-jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class RefreshJwtAuthGuard extends AuthGuard('refresh-jwt') {}

--- a/src/auth/strategy/jwt.strategy.ts
+++ b/src/auth/strategy/jwt.strategy.ts
@@ -1,7 +1,8 @@
+import { JwtPayload } from './../dto/jwt-token.dto';
+import { User } from 'src/users/entities/user.entity';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { JwtPayload } from '../dto/jwt-payload.dto';
 import { UsersRepository } from 'src/users/users.repository';
 
 @Injectable()
@@ -15,7 +16,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: JwtPayload) {
-    const user = this.usersRepository.findByUserId(payload.sub);
+    const user: User = await this.usersRepository.findByUserId(payload.sub);
     if (!user) {
       throw new UnauthorizedException();
     }

--- a/src/auth/strategy/jwt.strategy.ts
+++ b/src/auth/strategy/jwt.strategy.ts
@@ -16,7 +16,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: JwtPayload) {
-    const user: User = await this.usersRepository.findByUserId(payload.sub);
+    const user: User = await this.usersRepository.findByUserId(payload.userId);
     if (!user) {
       throw new UnauthorizedException();
     }

--- a/src/auth/strategy/refresh-jwt.strategy.ts
+++ b/src/auth/strategy/refresh-jwt.strategy.ts
@@ -23,7 +23,7 @@ export class RefreshJwtStrategy extends PassportStrategy(
   }
 
   async validate(payload: JwtPayload) {
-    const user: User = await this.usersRepository.findByUserId(payload.sub);
+    const user: User = await this.usersRepository.findByUserId(payload.userId);
     const tokenId = await this.authRepository.findToken(payload.uuid);
     if (!user || !tokenId) {
       throw new UnauthorizedException('user or token not found');


### PR DESCRIPTION
## 개발사항

jwt token 을 사용해 인가 시스템을 구축하였습니다.
refresh 토큰 안에 넣은 uuid 값을 token db에 저장하였습니다.

refresh 전략에서 passport 가 
1) 토큰의 시그니처 검사 2) 토큰의 유효기간 검사 를 해서 payload 를 넘겨주면
payload 값으로 3) 유저 존재 여부 검사 4) token db에 같은 uuid 을 가진 token이 존재하는지 검사 를 행한 뒤
payload 값을 return 합니다.

access 전략 (그냥 jwt 전략) 에서는  passport 가 
1) 토큰의 시그니처 검사 2) 토큰의 유효기간 검사 를 해서 payload 를 넘겨주면
payload 값으로 3) 유저 존재 여부 검사 만 해서
User 객체를 return 합니다.

토큰 관련해서 db와 access 하는 로직들은 모두 auth 레포에 넣어두었습니다.

현재 auth 컨트롤러에 refresh 할때와 logout 할때 refresh guard를 붙여두었습니다~
refresh => token db에서 해당 토큰 삭제 후 재발급
logout => token db에서 해당 토큰 삭제

close #30 

### 이전 상황

#30  : 이슈번호

### 개발 후 상황

passport 를 사용해 개발했음

### 테스트 항목

- [ ] refresh
- [ ] logout

---

## 추가사항

user table 컬럼 변경 되어 로직 수정해야되는건 다른 브렌치에서 할게요~